### PR TITLE
Fix: Replace \w+ with [\w-]+ to capture dashes in structure identifiers

### DIFF
--- a/tasks/spreadsheet/convert_spreadsheet_structures.py
+++ b/tasks/spreadsheet/convert_spreadsheet_structures.py
@@ -58,7 +58,7 @@ def _parse_identifier_value(identifier_str):
     result = {}
 
     # Try to match pattern with position and dates: ID[position][startDate-endDate]
-    match = re.match(r'^(\w+)\[(\d+)\]\[(\d+)(?:-(\d*))?\]$', identifier_str)
+    match = re.match(r'^([\w-]+)\[(\d+)\]\[(\d+)(?:-(\d*))?\]$', identifier_str)
     if match:
         result['value'] = match.group(1)
         result['position'] = match.group(2)
@@ -67,7 +67,7 @@ def _parse_identifier_value(identifier_str):
         return result
 
     # Try to match pattern with dates only: ID[startDate-endDate]
-    match = re.match(r'^(\w+)\[(\d+)(?:-(\d*))?\]$', identifier_str)
+    match = re.match(r'^([\w-]+)\[(\d+)(?:-(\d*))?\]$', identifier_str)
     if match:
         result['value'] = match.group(1)
         result['start_date'] = match.group(2)
@@ -75,7 +75,7 @@ def _parse_identifier_value(identifier_str):
         return result
 
     # Try to match pattern with empty brackets or subtype: ID[] or ID[subtype]
-    match = re.match(r'^(\w+)\[\w*\]$', identifier_str)
+    match = re.match(r'^([\w-]+)\[\w*\]$', identifier_str)
     if match:
         result['value'] = match.group(1)
         return result


### PR DESCRIPTION
- Update regex patterns in _parse_identifier_value() to handle identifiers with dashes
- Fixes parsing of identifiers like U_9015_D-4[20210101-] that were leaving brackets in the value
- Affects 3 regex patterns: position+dates, dates-only, and empty brackets patterns